### PR TITLE
Updated Dockerfile base image ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Distributed under the terms of the Modified BSD License.
-ARG BASE_CONTAINER=jupyter/scipy-notebook
+ARG BASE_CONTAINER=jupyter/scipy-notebook:python-3.7.12
 FROM $BASE_CONTAINER
 LABEL maintainer="Russell <rjjarvis@asu.edu>"
 USER root


### PR DESCRIPTION
The latest version of Python, 3.10.x on Ubuntu 22.04 LTS, is incompatible with PyPNS and its dependencies. So we set the base container reference to Python 3.7.12, Jupyter's last 3.7 tagged version.

Verified that test.py executes successfully. 