### PR TITLE
Update Dockerfile to correct x86_64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ USER jovyan
 WORKDIR src/nrnpython
 RUN python setup.py install
 RUN python -c "import neuron"
-ENV NEURON_HOME $HOME/nrn-7.7/x86_64
+ENV NEURON_HOME $HOME/nrn-7.7/aarch64
 ENV PATH $NEURON_HOME/bin:$PATH
 WORKDIR $HOME/work/extra_work
 WORKDIR $HOME/work


### PR DESCRIPTION
The current python and image file name for the x86_64 architecture is now "aarch64" changed from the previous "x86_64". The Dockerfile doesn't successfully run until this change is made to the location of the path